### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ sudo mv ~user/QubesIncoming/work/qubes.SshAgent /etc/qubes-rpc/
 
 - Client VM: append the contents of rc.local_client to /rw/config/rc.local
     * This is what starts the client side of the ssh agent
+    * Examine the contents and set $SSH_VAULT_VM appropriately
     * Be sure rc.local is executable. ie - `chmod +x /rw/config/rc.local`
 
 - Client VM: Append bashrc_client to the client VM's ~/.bashrc

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ the client AppVM.
 This was inspired by the Qubes [Split GPG](https://www.qubes-os.org/doc/split-gpg/).
 
 Other details:
-- This was developed/tested on the Fedora24 template in Qubes 3.2; it might work for other templates
+- This was developed/tested on the Fedora24 template in Qubes 3.2; it might work for other templates (you may need nmap installed on Debian, which provides the ncat utility used both in client and vault VMs)
 - You will be prompted to confirm each request, though like split GPG you won't see what was requested
 - Assumes that the ssh-vault template automatically starts ssh-agent
 - One can have an arbitrary number of ssh-vault VMs
@@ -33,14 +33,13 @@ Copy files from this repo to various destinations (VM is the first argument). Yo
 - Dom0: Copy qubes.SshAgent.policy to dom0's /etc/qubes-rpc/policy/qubes.SshAgent
 
 - Template for Ssh Vault: Copy qubes.SshAgent to /etc/qubes-rpc/qubes.SshAgent in the template image for the Ssh Vault VM.
-    * qubes.SshAgent needs to run at startup in the AppVM that would like to use the key, as it makes the conduit of the ssh agent forwarding
     * This is because /etc is lost on every boot for the vault itself, so it needs to be added to the template
     * Example:
 ```bash
 # From the VM with the git repo
 qvm-copy-to-vm fedora-24 qubes.SshAgent
 
-# On the template (in this case, fedora-24), run:
+# On the ssh-vault's template (in this case, fedora-24), run:
 sudo mv ~user/QubesIncoming/work/qubes.SshAgent /etc/qubes-rpc/
 ```
 - Create the ssh-vault VM (default name is "ssh-vault" in the scripts below)
@@ -48,10 +47,8 @@ sudo mv ~user/QubesIncoming/work/qubes.SshAgent /etc/qubes-rpc/
 
 - Ssh-vault: Create an ssh private key or copy one in
 
-
 - Client VM: append the contents of rc.local_client to /rw/config/rc.local
     * This is what starts the client side of the ssh agent
-    * Examine the contents and set $SSH_VAULT_VM appropriately
     * Be sure rc.local is executable. ie - `chmod +x /rw/config/rc.local`
 
 - Client VM: Append bashrc_client to the client VM's ~/.bashrc

--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ sudo mv ~user/QubesIncoming/work/qubes.SshAgent /etc/qubes-rpc/
     * It's recommended to disable network access for this VM
 
 - Ssh-vault: Create an ssh private key or copy one in
+    * Add the ssh-add.desktop file into ~user/.config/autostart in the ssh-vault VM
+      (you may need to create the .config/autostart directory if it doesn't already exist)
+      Examine the contents of this file and adjust the ssh-add command if desired (e.g
+      you may want to pass a specific SSH key to add to the agent)
 
 - Client VM: append the contents of rc.local_client to /rw/config/rc.local
     * This is what starts the client side of the ssh agent
@@ -56,11 +60,7 @@ sudo mv ~user/QubesIncoming/work/qubes.SshAgent /etc/qubes-rpc/
     * This sets the user's $SSH_AUTH_SOCK to the appropriate value
     * Examine the contents and set $SSH_VAULT_VM appropriately
 
-- Every boot, you will need to run "ssh-add" on the ssh-vault VM to add your key(s) into the ssh-agent.
-
 # Todo
-
-- Automate adding an ssh key in the ssh-vault VM
 
 - Convert the client rc.local into a systemd script in the client template, and allow the ssh-vault VM to be set using some well-known file (like /rw/config/ssh-vault)
 	- Maybe do the above using qvm-service or qubesdb

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ sudo mv ~user/QubesIncoming/work/qubes.SshAgent /etc/qubes-rpc/
 - Ssh-vault: Create an ssh private key or copy one in
     * Add the ssh-add.desktop file into ~user/.config/autostart in the ssh-vault VM
       (you may need to create the .config/autostart directory if it doesn't already exist)
-      Examine the contents of this file and adjust the ssh-add command if desired (e.g
+    * Examine the contents of this file and adjust the ssh-add command if desired (e.g
       you may want to pass a specific SSH key to add to the agent)
 
 - Client VM: append the contents of rc.local_client to /rw/config/rc.local

--- a/ssh-add.desktop
+++ b/ssh-add.desktop
@@ -1,0 +1,4 @@
+[Desktop Entry]
+Name=ssh-add
+Exec=ssh-add
+Type=Application


### PR DESCRIPTION
Adds more about nmap on Debian for ncat utility
Removes confusing sentence re: qubes.SshAgent starting at boot (handled later in the rc.local of the client VM)