### PR TITLE
Change ncat's socket permissions to more secured ones.

### DIFF
--- a/rc.local_client
+++ b/rc.local_client
@@ -4,6 +4,6 @@ SSH_VAULT_VM="ssh-vault"
 if [ "$SSH_VAULT_VM" != "" ]; then
 	export SSH_SOCK=/tmp/.SSH_AGENT_$SSH_VAULT_VM
 	rm -f "$SSH_SOCK"
-	sudo -u user ncat -k -l -U "$SSH_SOCK" -c "qrexec-client-vm $SSH_VAULT_VM qubes.SshAgent" &
+	sudo -u user /bin/sh -c "umask 0177 && ncat -k -l -U '$SSH_SOCK' -c 'qrexec-client-vm $SSH_VAULT_VM qubes.SshAgent' &"
 fi
 


### PR DESCRIPTION
Hi,

First of all, thanks for this nice Qubes addon ;)

I tested it without any problems but I noticed that the socket permissions created by ncat on the client VM depends on the system umask. Consequently, as the default umask is 0022 on most systems, the socket will get insecured permissions (world readable).

The following pull request just set a more secured umask before calling ncat. The socket will now get the same permissions than a classic SSH agent.

