### PR TITLE
send a notification when SSH agent is accessed and from what domain

### DIFF
--- a/qubes.SshAgent
+++ b/qubes.SshAgent
@@ -1,3 +1,3 @@
 #!/bin/sh
-
+notify-send "SSH agent access from domain: $QREXEC_REMOTE_DOMAIN"
 ncat -U $SSH_AUTH_SOCK


### PR DESCRIPTION
This adds the notify-send command to show a notification to the desktop when a VM accesses the agent (same as what Split GPG does)