### PR TITLE
Fixes https://github.com/henn/qubes-app-split-ssh/issues/6

### DIFF
--- a/rc.local_client
+++ b/rc.local_client
@@ -2,7 +2,7 @@
 SSH_VAULT_VM="ssh-vault"
 
 if [ "$SSH_VAULT_VM" != "" ]; then
-	export SSH_SOCK=~user/.SSH_AGENT_$SSH_VAULT_VM
+	export SSH_SOCK=/home/user/.SSH_AGENT_$SSH_VAULT_VM
 	rm -f "$SSH_SOCK"
 	sudo -u user /bin/sh -c "umask 177 && ncat -k -l -U '$SSH_SOCK' -c 'qrexec-client-vm $SSH_VAULT_VM qubes.SshAgent' &"
 fi


### PR DESCRIPTION
I think the problem is that /bin/sh links to /bin/bash in Fedora systems, but in Debian 8 it links to [/bin/dash](https://wiki.ubuntu.com/DashAsBinSh), this might be the reason why Debian systems won't rm the SSH socket. I don't why the ~user expansion fails, but this fixes it on my Debian 8 standalone vm ;)